### PR TITLE
Version 2.3.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an eror that stops the checkout process and informs the customer that the shipping methods have changed.
+* Added a filter `krokedil_shipping_changed_auto_correct` to allow developers to auto-correct the shipping method if it has been changed during the checkout process. This is useful if you want to automatically set the shipping method to the first available one instead of throwing an error. However this is not recommended as it can lead to unexpected issues if the chosen method is no longer available.
+* Added a filter `krokedil_shipping_changed_throw_error` to allow merchants or plugins to disable the error handling for shipping methods that have been changed during the checkout process. This is useful if you want to handle the error in your own way, or if you want to disable the error handling completely, for example for specific payment or shipping methods.
+
+### Fixed
+* Fixed an issue where the shipping methods selected pickup point would be reset in some cases when the shipping methods were recalculated.
+
 ------------------
 
 ## [2.2.0] - 2025-06-09

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an eror that stops the checkout process and informs the customer that the shipping methods have changed.
+* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an eror that stops the checkout process and informs the customer that the shipping methods have changed. This has to be enabled with the filter `krokedil_shipping_should_verify_shipping` which is set to false by default to prevent unvanted behavior in existing setups.
 * Added a filter `krokedil_shipping_changed_auto_correct` to allow developers to auto-correct the shipping method if it has been changed during the checkout process. This is useful if you want to automatically set the shipping method to the first available one instead of throwing an error. However this is not recommended as it can lead to unexpected issues if the chosen method is no longer available.
 * Added a filter `krokedil_shipping_changed_throw_error` to allow merchants or plugins to disable the error handling for shipping methods that have been changed during the checkout process. This is useful if you want to handle the error in your own way, or if you want to disable the error handling completely, for example for specific payment or shipping methods.
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+------------------
+## [2.3.0] - 2025-07-16
+
 ### Added
-* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an eror that stops the checkout process and informs the customer that the shipping methods have changed. This has to be enabled with the filter `krokedil_shipping_should_verify_shipping` which is set to false by default to prevent unvanted behavior in existing setups.
+* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an error that stops the checkout process and informs the customer that the shipping methods have changed. This has to be enabled with the filter `krokedil_shipping_should_verify_shipping` which is set to false by default to prevent unwanted behavior in existing setups.
 * Added a filter `krokedil_shipping_changed_auto_correct` to allow developers to auto-correct the shipping method if it has been changed during the checkout process. This is useful if you want to automatically set the shipping method to the first available one instead of throwing an error. However this is not recommended as it can lead to unexpected issues if the chosen method is no longer available.
 * Added a filter `krokedil_shipping_changed_throw_error` to allow merchants or plugins to disable the error handling for shipping methods that have been changed during the checkout process. This is useful if you want to handle the error in your own way, or if you want to disable the error handling completely, for example for specific payment or shipping methods.
 
 ### Fixed
 * Fixed an issue where the shipping methods selected pickup point would be reset in some cases when the shipping methods were recalculated.
-
-------------------
 
 ## [2.2.0] - 2025-06-09
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "krokedil/shipping",
     "description": "Shipping method extensions from Krokedil",
     "type": "library",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "require": {
         "php": "~7.4 || ~8.0",
         "psr/container": "2.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
             "Krokedil\\Shipping\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Krokedil\\Shipping\\Tests\\": "tests/"
+        }
+    },
     "archive": {
         "exclude": [
             "tests/*",

--- a/docs/PickupPoint/PickupPoint.md
+++ b/docs/PickupPoint/PickupPoint.md
@@ -16,11 +16,16 @@ Contains the data for a pickup point.
 |[get_coordinates](#pickuppointget_coordinates)|Get the coordinates.|
 |[get_description](#pickuppointget_description)|Get the description.|
 |[get_eta](#pickuppointget_eta)|Get the estimated time of arrival.|
+|[get_from_order](#pickuppointget_from_order)|Get pickup points from order.|
 |[get_id](#pickuppointget_id)|Get the ID.|
 |[get_meta_data](#pickuppointget_meta_data)|Get the meta data.|
 |[get_name](#pickuppointget_name)|Get the name.|
 |[get_open_hours](#pickuppointget_open_hours)|Get the opening hours.|
+|[get_selected_from_order](#pickuppointget_selected_from_order)|Get selected from order.|
 |[json_to_array](#pickuppointjson_to_array)|Convert a JSON string to an array.|
+|[print_address](#pickuppointprint_address)|Print the address as a formatted HTML output.|
+|[print_google_maps_link](#pickuppointprint_google_maps_link)|Print a google maps link to the pickup point.|
+|[print_open_hours](#pickuppointprint_open_hours)|Print the Opening hours as a formatted HTML output.|
 |[set_address](#pickuppointset_address)|Set the address.|
 |[set_coordinates](#pickuppointset_coordinates)|Set the coordinates.|
 |[set_description](#pickuppointset_description)|Set the description.|
@@ -194,6 +199,33 @@ Get the estimated time of arrival.
 <hr />
 
 
+### PickupPoint::get_from_order  
+
+**Description**
+
+```php
+public static get_from_order (\WC_Order $order)
+```
+
+Get pickup points from order. 
+
+ 
+
+**Parameters**
+
+* `(\WC_Order) $order`
+: The WooCommerce order.  
+
+**Return Values**
+
+`\PickupPoint[]|bool`
+
+
+
+
+<hr />
+
+
 ### PickupPoint::get_id  
 
 **Description**
@@ -299,6 +331,33 @@ Get the opening hours.
 <hr />
 
 
+### PickupPoint::get_selected_from_order  
+
+**Description**
+
+```php
+public static get_selected_from_order (\WC_Order $order)
+```
+
+Get selected from order. 
+
+ 
+
+**Parameters**
+
+* `(\WC_Order) $order`
+: The WooCommerce order.  
+
+**Return Values**
+
+`\PickupPoint|bool`
+
+
+
+
+<hr />
+
+
 ### PickupPoint::json_to_array  
 
 **Description**
@@ -319,6 +378,85 @@ Convert a JSON string to an array.
 **Return Values**
 
 `array`
+
+
+
+
+<hr />
+
+
+### PickupPoint::print_address  
+
+**Description**
+
+```php
+public print_address (bool $no_title)
+```
+
+Print the address as a formatted HTML output. 
+
+ 
+
+**Parameters**
+
+* `(bool) $no_title`
+: Whether to print the title or not.  
+
+**Return Values**
+
+`void`
+
+
+
+
+<hr />
+
+
+### PickupPoint::print_google_maps_link  
+
+**Description**
+
+```php
+public print_google_maps_link (void)
+```
+
+Print a google maps link to the pickup point. 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+
+
+<hr />
+
+
+### PickupPoint::print_open_hours  
+
+**Description**
+
+```php
+public print_open_hours (void)
+```
+
+Print the Opening hours as a formatted HTML output. 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
 
 
 

--- a/docs/PickupPoints.md
+++ b/docs/PickupPoints.md
@@ -2,7 +2,7 @@
 
 Class PickupPoints
 
-Handles the pickup points service and any integraction with WooCommerce that is required for the package to work properly.
+Handles the pickup points service and any interaction with WooCommerce that is required for the package to work properly.
 Offloading this from the plugins that implement it to a service class.  
 
 ## Implements:
@@ -16,16 +16,20 @@ Krokedil\Shipping\Interfaces\PickupPointServiceInterface
 |------|-------------|
 |[__construct](#pickuppoints__construct)|Class constructor.|
 |[add_hidden_order_itemmeta](#pickuppointsadd_hidden_order_itemmeta)|Add the order line metadata for pickup points to the list of hidden meta data.|
-|[add_pickup_point_to_rate](#pickuppointsadd_pickup_point_to_rate)|{@inheritDoc}|
-|[get_container](#pickuppointsget_container)|{@inheritDoc}|
-|[get_pickup_point_from_rate_by_id](#pickuppointsget_pickup_point_from_rate_by_id)|{@inheritDoc}|
-|[get_pickup_points_from_rate](#pickuppointsget_pickup_points_from_rate)|{@inheritDoc}|
-|[get_selected_pickup_point_from_rate](#pickuppointsget_selected_pickup_point_from_rate)|{@inheritDoc}|
+|[add_pickup_point_to_rate](#pickuppointsadd_pickup_point_to_rate)|Add a pickup point to the rate.|
+|[get_container](#pickuppointsget_container)|Retrieve the container that holds all the registered services for the pickup point service.|
+|[get_pickup_point_from_rate_by_id](#pickuppointsget_pickup_point_from_rate_by_id)|Get a pickup point from a rate by id.|
+|[get_pickup_points_from_rate](#pickuppointsget_pickup_points_from_rate)|Get the pickup points for a specific rate.|
+|[get_selected_pickup_point_from_rate](#pickuppointsget_selected_pickup_point_from_rate)|Get the selected pickup point for a specific rate. If no pickup point is selected, returns false.|
+|[get_selected_pickup_point_from_rate_session](#pickuppointsget_selected_pickup_point_from_rate_session)|Get the selected pickup point from the session for a rate.|
+|[get_selected_pickup_point_from_session](#pickuppointsget_selected_pickup_point_from_session)|Get the selected pickup point from the session.|
+|[get_shipping_lines_from_order](#pickuppointsget_shipping_lines_from_order)|Return any pickup point shipping methods from a WooCommerce order.|
 |[init](#pickuppointsinit)|Initialize the class instance.|
 |[json_to_array](#pickuppointsjson_to_array)|Convert a JSON string to an array.|
-|[remove_pickup_point_from_rate](#pickuppointsremove_pickup_point_from_rate)|{@inheritDoc}|
-|[save_pickup_points_to_rate](#pickuppointssave_pickup_points_to_rate)|{@inheritDoc}|
-|[save_selected_pickup_point_to_rate](#pickuppointssave_selected_pickup_point_to_rate)|{@inheritDoc}|
+|[remove_pickup_point_from_rate](#pickuppointsremove_pickup_point_from_rate)|Remove a pickup point from the rate.|
+|[save_pickup_points_to_rate](#pickuppointssave_pickup_points_to_rate)|Save the pickup points for a specific rate.|
+|[save_selected_pickup_point_to_rate](#pickuppointssave_selected_pickup_point_to_rate)|Save the selected pickup point for a specific rate.|
+|[save_selected_pickup_point_to_session](#pickuppointssave_selected_pickup_point_to_session)|Save the selected pickup point for a specific rate.|
 |[to_array](#pickuppointsto_array)|Convert an object to an array.|
 |[to_json](#pickuppointsto_json)|Convert an array to a JSON string.|
 
@@ -91,20 +95,25 @@ Add the order line metadata for pickup points to the list of hidden meta data.
 **Description**
 
 ```php
-public add_pickup_point_to_rate (void)
+public add_pickup_point_to_rate (\WC_Shipping_Rate $rate, \PickupPoint $pickup_point)
 ```
 
-{@inheritDoc} 
+Add a pickup point to the rate. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to add the pickup point to.  
+* `(\PickupPoint) $pickup_point`
+: The pickup point to add.  
 
 **Return Values**
 
 `void`
+
+
 
 
 <hr />
@@ -118,7 +127,7 @@ public add_pickup_point_to_rate (void)
 public get_container (void)
 ```
 
-{@inheritDoc} 
+Retrieve the container that holds all the registered services for the pickup point service. 
 
  
 
@@ -128,7 +137,9 @@ public get_container (void)
 
 **Return Values**
 
-`void`
+`\Container`
+
+
 
 
 <hr />
@@ -139,20 +150,25 @@ public get_container (void)
 **Description**
 
 ```php
-public get_pickup_point_from_rate_by_id (void)
+public get_pickup_point_from_rate_by_id (\WC_Shipping_Rate $rate, string $id)
 ```
 
-{@inheritDoc} 
+Get a pickup point from a rate by id. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to get the pickup point from.  
+* `(string) $id`
+: The id of the pickup point to get.  
 
 **Return Values**
 
-`void`
+`\PickupPoint|null`
+
+
 
 
 <hr />
@@ -163,20 +179,23 @@ public get_pickup_point_from_rate_by_id (void)
 **Description**
 
 ```php
-public get_pickup_points_from_rate (void)
+public get_pickup_points_from_rate (\WC_Shipping_Rate $rate)
 ```
 
-{@inheritDoc} 
+Get the pickup points for a specific rate. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to get the pickup points from.  
 
 **Return Values**
 
-`void`
+`\PickupPoint[]`
+
+
 
 
 <hr />
@@ -187,10 +206,64 @@ public get_pickup_points_from_rate (void)
 **Description**
 
 ```php
-public get_selected_pickup_point_from_rate (void)
+public get_selected_pickup_point_from_rate (\WC_Shipping_Rate $rate)
 ```
 
-{@inheritDoc} 
+Get the selected pickup point for a specific rate. If no pickup point is selected, returns false. 
+
+ 
+
+**Parameters**
+
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to get the selected pickup point from.  
+
+**Return Values**
+
+`\PickupPoint|bool`
+
+
+
+
+<hr />
+
+
+### PickupPoints::get_selected_pickup_point_from_rate_session  
+
+**Description**
+
+```php
+public get_selected_pickup_point_from_rate_session (\WC_Shipping_Rate $rate)
+```
+
+Get the selected pickup point from the session for a rate. 
+
+ 
+
+**Parameters**
+
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to get the selected pickup point from.  
+
+**Return Values**
+
+`\PickupPoint|bool`
+
+
+
+
+<hr />
+
+
+### PickupPoints::get_selected_pickup_point_from_session  
+
+**Description**
+
+```php
+public get_selected_pickup_point_from_session (void)
+```
+
+Get the selected pickup point from the session. 
 
  
 
@@ -200,7 +273,36 @@ public get_selected_pickup_point_from_rate (void)
 
 **Return Values**
 
-`void`
+`\PickupPoint|bool`
+
+
+
+
+<hr />
+
+
+### PickupPoints::get_shipping_lines_from_order  
+
+**Description**
+
+```php
+public get_shipping_lines_from_order (\WC_Order $order)
+```
+
+Return any pickup point shipping methods from a WooCommerce order. 
+
+ 
+
+**Parameters**
+
+* `(\WC_Order) $order`
+: The WooCommerce order.  
+
+**Return Values**
+
+`array|bool`
+
+
 
 
 <hr />
@@ -265,20 +367,25 @@ Convert a JSON string to an array.
 **Description**
 
 ```php
-public remove_pickup_point_from_rate (void)
+public remove_pickup_point_from_rate (\WC_Shipping_Rate $rate, \PickupPoint $pickup_point)
 ```
 
-{@inheritDoc} 
+Remove a pickup point from the rate. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to remove the pickup point from.  
+* `(\PickupPoint) $pickup_point`
+: The pickup point to remove.  
 
 **Return Values**
 
 `void`
+
+
 
 
 <hr />
@@ -289,20 +396,25 @@ public remove_pickup_point_from_rate (void)
 **Description**
 
 ```php
-public save_pickup_points_to_rate (void)
+public save_pickup_points_to_rate (\WC_Shipping_Rate $rate, \PickupPoint[] $pickup_points)
 ```
 
-{@inheritDoc} 
+Save the pickup points for a specific rate. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to save the pickup points to.  
+* `(\PickupPoint[]) $pickup_points`
+: The pickup points to save.  
 
 **Return Values**
 
 `void`
+
+
 
 
 <hr />
@@ -313,20 +425,52 @@ public save_pickup_points_to_rate (void)
 **Description**
 
 ```php
-public save_selected_pickup_point_to_rate (void)
+public save_selected_pickup_point_to_rate (\WC_Shipping_Rate $rate, \PickupPoint $pickup_point)
 ```
 
-{@inheritDoc} 
+Save the selected pickup point for a specific rate. 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(\WC_Shipping_Rate) $rate`
+: The WooCommerce shipping rate to save the selected pickup point to.  
+* `(\PickupPoint) $pickup_point`
+: The pickup point to save.  
 
 **Return Values**
 
 `void`
+
+
+
+
+<hr />
+
+
+### PickupPoints::save_selected_pickup_point_to_session  
+
+**Description**
+
+```php
+public save_selected_pickup_point_to_session (\PickupPoint $pickup_point)
+```
+
+Save the selected pickup point for a specific rate. 
+
+ 
+
+**Parameters**
+
+* `(\PickupPoint) $pickup_point`
+: The pickup point to save.  
+
+**Return Values**
+
+`void`
+
+
 
 
 <hr />

--- a/src/PickupPoints.php
+++ b/src/PickupPoints.php
@@ -52,6 +52,7 @@ class PickupPoints implements PickupPointServiceInterface {
 		// Setup the container with the dependent services.
 		$this->container = Container::get_instance();
 
+		$this->container->add( 'pickup-points', $this );
 		$this->container->add( 'session-handler', new SessionHandler() );
 		$this->container->add( 'ajax', new AJAX() );
 		$this->container->add( 'assets', new Assets() );
@@ -206,7 +207,29 @@ class PickupPoints implements PickupPointServiceInterface {
 			'krokedil_selected_pickup_point_id' => $pickup_point->get_id(),
 		);
 
+		$this->save_selected_pickup_point_to_session( $pickup_point );
 		$this->save_shipping_rate_data( $rate, $data );
+	}
+
+		/**
+	 * Save the selected pickup point for a specific rate.
+	 *
+	 * @param \WC_Shipping_Rate $rate The WooCommerce shipping rate to save the selected pickup point to.
+	 * @param PickupPoint       $pickup_point The pickup point to save.
+	 *
+	 * @return void
+	 */
+	public function save_selected_pickup_point_to_session( $pickup_point ) {
+		$pickup_point_json = $this->to_json( $pickup_point );
+
+		$data = array(
+			'krokedil_selected_pickup_point'    => $pickup_point_json,
+			'krokedil_selected_pickup_point_id' => $pickup_point->get_id(),
+		);
+
+		// Save the data to the session 'krokedil_selected_pickup_point' and 'krokedil_selected_pickup_point_id'.
+		WC()->session->set( 'krokedil_selected_pickup_point', $data['krokedil_selected_pickup_point'] );
+		WC()->session->set( 'krokedil_selected_pickup_point_id', $data['krokedil_selected_pickup_point_id'] );
 	}
 
 	/**
@@ -217,12 +240,70 @@ class PickupPoints implements PickupPointServiceInterface {
 	 * @return PickupPoint|bool
 	 */
 	public function get_selected_pickup_point_from_rate( $rate ) {
+		// Try to get the selected pickup point id from the session if it exists.
+		$session_pickup_point_id = WC()->session->get( 'krokedil_selected_pickup_point_id' );
+
+		// See if the rate still has the pickup point for the sessions selected id.
+		if ( $session_pickup_point_id ) {
+			$session_pickup_point = $this->get_pickup_point_from_rate_by_id( $rate, $session_pickup_point_id );
+
+			// Return the pickup point if it exists in the rate.
+			if ( $session_pickup_point ) {
+				return $session_pickup_point;
+			}
+		}
+
 		$meta_data = $rate->get_meta_data();
 		if ( ! array_key_exists( 'krokedil_selected_pickup_point', $meta_data ) ) {
 			return false;
 		}
 
 		$pickup_point_array = $this->json_to_array( $meta_data['krokedil_selected_pickup_point'] );
+
+		return new PickupPoint( $pickup_point_array );
+	}
+
+	/**
+	 * Get the selected pickup point from the session for a rate.
+	 *
+	 * @param \WC_Shipping_Rate $rate The WooCommerce shipping rate to get the selected pickup point from.
+	 *
+	 * @return PickupPoint|bool
+	 */
+	public function get_selected_pickup_point_from_rate_session( $rate ) {
+		// Try to get the selected pickup point id from the session if it exists.
+		$session_pickup_point_id = WC()->session->get( 'krokedil_selected_pickup_point_id' );
+
+		// See if the rate still has the pickup point for the sessions selected id.
+		if ( empty( $session_pickup_point_id ) ) {
+			return false;
+		}
+
+		$session_pickup_point = $this->get_pickup_point_from_rate_by_id( $rate, $session_pickup_point_id );
+
+		// Return the pickup point if it exists in the rate.
+		if ( empty( $session_pickup_point ) ) {
+			return false;
+		}
+
+		return $session_pickup_point;
+	}
+
+	/**
+	 * Get the selected pickup point from the session.
+	 *
+	 * @return PickupPoint|bool
+	 */
+	public function get_selected_pickup_point_from_session() {
+		// Try to get the selected pickup point from the session.
+		$session_pickup_point = WC()->session->get( 'krokedil_selected_pickup_point' );
+
+		// See if the rate still has the pickup point for the sessions selected id.
+		if ( empty( $session_pickup_point ) ) {
+			return false;
+		}
+
+		$pickup_point_array = $this->json_to_array( $session_pickup_point['krokedil_selected_pickup_point'] );
 
 		return new PickupPoint( $pickup_point_array );
 	}

--- a/src/PickupPoints.php
+++ b/src/PickupPoints.php
@@ -211,11 +211,10 @@ class PickupPoints implements PickupPointServiceInterface {
 		$this->save_shipping_rate_data( $rate, $data );
 	}
 
-		/**
+	/**
 	 * Save the selected pickup point for a specific rate.
 	 *
-	 * @param \WC_Shipping_Rate $rate The WooCommerce shipping rate to save the selected pickup point to.
-	 * @param PickupPoint       $pickup_point The pickup point to save.
+	 * @param PickupPoint $pickup_point The pickup point to save.
 	 *
 	 * @return void
 	 */

--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -178,7 +178,7 @@ class SessionHandler {
 		foreach ( $rates as $rate ) {
 			$pickup_point = $pickup_points_service->get_pickup_point_from_rate_by_id( $rate, $session_pickup_point_id );
 
-			if(empty($pickup_point)) {
+			if ( empty( $pickup_point ) ) {
 				continue;
 			}
 

--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -1,6 +1,8 @@
 <?php
 namespace Krokedil\Shipping;
 
+use Krokedil\Shipping\Container\Container;
+
 /**
  * Class SessionHandler
  *
@@ -17,10 +19,21 @@ class SessionHandler {
 	private $shipping_rate_data = array();
 
 	/**
+	 * The pickup points service to use for getting the pickup points.
+	 *
+	 * @var Container
+	 */
+	private $container;
+
+	/**
 	 * Class constructor.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
+		$this->container = Container::get_instance();
 		add_filter( 'woocommerce_package_rates', array( $this, 'package_rates_handler' ), 10, 1 );
+		add_filter( 'woocommerce_package_rates', array( $this, 'set_selected_pickup_point_from_session' ), 20, 1 );
 	}
 
 	/**
@@ -143,5 +156,33 @@ class SessionHandler {
 
 			$this->shipping_rate_data[ $rate->get_id() ] = $rate_meta;
 		}
+	}
+
+	/**
+	 * Set the selected pickup point from the session after shipping has been calculated.
+	 *
+	 * @param \WC_Shipping_Rate[] $rates The shipping rates to set the selected pickup point for.
+	 *
+	 * @return \WC_Shipping_Rate[] The updated shipping rates with the selected pickup point set.
+	 */
+	public function set_selected_pickup_point_from_session( $rates ) {
+		$session_pickup_point_id = WC()->session->get( 'krokedil_selected_pickup_point_id' );
+		if ( ! $session_pickup_point_id ) {
+			return $rates;
+		}
+
+		$pickup_points_service = $this->container->get( 'pickup-points' );
+		foreach ( $rates as $rate ) {
+			$pickup_point = $pickup_points_service->get_pickup_point_from_rate_by_id( $rate, $session_pickup_point_id );
+
+			if(empty($pickup_point)) {
+				continue;
+			}
+
+			// If the pickup point is set, we can set the selected pickup point to the shipping rate.
+			$pickup_points_service->save_selected_pickup_point_to_rate( $rate, $pickup_point );
+		}
+
+		return $rates;
 	}
 }

--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -34,6 +34,9 @@ class SessionHandler {
 		$this->container = Container::get_instance();
 		add_filter( 'woocommerce_package_rates', array( $this, 'package_rates_handler' ), 10, 1 );
 		add_filter( 'woocommerce_package_rates', array( $this, 'set_selected_pickup_point_from_session' ), 20, 1 );
+
+		add_filter( 'woocommerce_shipping_chosen_method', array( __CLASS__, 'maybe_register_shipping_error' ), PHP_INT_MAX, 3 );
+		add_action( 'woocommerce_shipping_method_chosen', array( __CLASS__, 'maybe_throw_shipping_error' ), PHP_INT_MAX );
 	}
 
 	/**
@@ -184,5 +187,61 @@ class SessionHandler {
 		}
 
 		return $rates;
+	}
+
+	/**
+	 * Maybe registers an error if we are attempting to set a new shipping method during the checkout process.
+	 * WooCommerce will in some cases reset the shipping selection, instead of throwing an error if shipping options
+	 * have changed. In our case its better to throw an error for the customer to see, so they can try again
+	 * or select another shipping option.
+	 *
+	 * @param string $default The shipping method id that would be set as the default method.
+	 * @param array  $rates The rates calculated when getting the default shipping method.
+	 * @param string $chosen_method The shipping method id that was chosen by the customer.
+	 *
+	 * @return string
+	 */
+	public static function maybe_register_shipping_error( $default, $rates, $chosen_method ) {
+		// Only do this if we are during the checkout process.
+		if ( did_action( 'woocommerce_checkout_process' ) <= 0 ) {
+			return $default;
+		}
+
+		// This covers for situations where the shipping rate packages may be changed through a hook, which may result in an incorrect shipping method change assessment.
+		if ( empty( $chosen_method ) || $default === $chosen_method ) {
+			return $default;
+		}
+
+		/*
+		 * Add a filter to allow people to set if they want to automatically correct shipping discrepancies instead of throwing an error.
+		 * Note however that this is not recommended. If you do this, and the shipping method that the customer selected is no longer available,
+		 * then unexpected issues might happen. Only do this if you are sure the chosen method actually exists and is available.
+		 */
+		if ( apply_filters( 'krokedil_shipping_changed_auto_correct', false, $default, $rates, $chosen_method ) ) {
+			return $chosen_method;
+		}
+
+		// If we are not auto-correcting the shipping method, we return the default, but trigger our action. This is so we can throw the error at a later time.
+		if( apply_filters( 'krokedil_shipping_changed_throw_error', true, $default, $rates, $chosen_method ) ) {
+			do_action( 'krokedil_shipping_changed_error' );
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Actually throws the error registered previously.
+	 * This is moved to happen on a separate action instead, since we need to allow WooCommerce to set a couple sessions.
+	 * This prevents customers needing to reload the page.
+	 *
+	 * @return void
+	 * @throws \Exception Exception with the error message.
+	 */
+	public static function maybe_throw_shipping_error() {
+		if ( did_action( 'krokedil_shipping_changed_error' ) <= 0 ) {
+			return;
+		}
+
+		throw new \Exception( __( 'The shipping methods have been changed during the checkout process. Please verify your selected shipping method and try again.', 'krokedil-shipping' ) );
 	}
 }

--- a/src/SessionHandler.php
+++ b/src/SessionHandler.php
@@ -207,6 +207,11 @@ class SessionHandler {
 			return $default;
 		}
 
+		// Only if the chosen shipping or payment method enables this.
+		if ( apply_filters( 'krokedil_shipping_should_verify_shipping', false, $default, $rates, $chosen_method ) ) {
+			return $default;
+		}
+
 		// This covers for situations where the shipping rate packages may be changed through a hook, which may result in an incorrect shipping method change assessment.
 		if ( empty( $chosen_method ) || $default === $chosen_method ) {
 			return $default;

--- a/tests/AJAXTest.php
+++ b/tests/AJAXTest.php
@@ -1,11 +1,13 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\AJAX;
 use WP_Mock\Tools\TestCase;
 
 class AJAXTest extends TestCase {
 	public function testCanAddAjaxEvents() {
 		$this->expectNotToPerformAssertions();
-		WP_Mock::expectActionAdded( 'wc_ajax_test', array( $this, 'test_callback' ) );
+		\WP_Mock::expectActionAdded( 'wc_ajax_test', array( $this, 'test_callback' ) );
 
 		$ajax = new AJAX();
 		$ajax->add_ajax_events(
@@ -17,7 +19,7 @@ class AJAXTest extends TestCase {
 
 	public function testCanAddAjaxEvent() {
 		$this->expectNotToPerformAssertions();
-		WP_Mock::expectActionAdded( 'wc_ajax_test', array( $this, 'test_callback' ) );
+		\WP_Mock::expectActionAdded( 'wc_ajax_test', array( $this, 'test_callback' ) );
 
 		$ajax = new AJAX();
 		$ajax->add_ajax_event(

--- a/tests/Admin/EditOrderPageTest.php
+++ b/tests/Admin/EditOrderPageTest.php
@@ -1,5 +1,8 @@
 <?php
+namespace Krokedil\Shipping\Tests\Admin;
+
 use Krokedil\Shipping\Admin\EditOrderPage;
+use Krokedil\Shipping\Tests\BaseTestCase;
 
 class EditOrderPageTest extends BaseTestCase {
 	/**
@@ -10,9 +13,9 @@ class EditOrderPageTest extends BaseTestCase {
 	public function testConstructor() {
 		$this->mockPickupPointService();
 		$editOrderPage = new EditOrderPage( $this->mockPickupPointService );
-		WP_Mock::expectActionAdded( 'add_meta_boxes', array( $editOrderPage, 'add_shipping_metabox' ), 10, 2 );
-		WP_Mock::expectActionAdded( 'ks_metabox_content', array( $editOrderPage, 'print_selected_pickup_point_info' ), 10, 2 );
-		WP_Mock::expectActionAdded( 'ks_metabox_content', array( $editOrderPage, 'print_selected_pickup_point_selection' ), 20, 2 );
+		\WP_Mock::expectActionAdded( 'add_meta_boxes', array( $editOrderPage, 'add_shipping_metabox' ), 10, 2 );
+		\WP_Mock::expectActionAdded( 'ks_metabox_content', array( $editOrderPage, 'print_selected_pickup_point_info' ), 10, 2 );
+		\WP_Mock::expectActionAdded( 'ks_metabox_content', array( $editOrderPage, 'print_selected_pickup_point_selection' ), 20, 2 );
 		$editOrderPage->init();
 		$this->assertInstanceOf( EditOrderPage::class, $editOrderPage );
 	}
@@ -20,14 +23,14 @@ class EditOrderPageTest extends BaseTestCase {
 	public function testCanAddShippingMetabox() {
 		$this->mockPickupPointService();
 		$this->editOrderPage = new EditOrderPage( $this->mockPickupPointService );
-		$order = Mockery::mock( 'alias:WC_Order' );
-		$shippingLine = Mockery::mock( 'alias:WC_Order_Item_Shipping' );
+		$order = \Mockery::mock( 'alias:WC_Order' );
+		$shippingLine = \Mockery::mock( 'alias:WC_Order_Item_Shipping' );
 		$this->mockPickupPointService
 			->shouldReceive( 'get_shipping_lines_from_order' )
 			->with($order)
 			->once()
 			->andReturn( array( $shippingLine ) );
-		WP_Mock::userFunction( 'add_meta_box' )
+		\WP_Mock::userFunction( 'add_meta_box' )
 			->once()
 			->with(
 				'krokedil_shipping',
@@ -46,8 +49,8 @@ class EditOrderPageTest extends BaseTestCase {
 	public function testRenderShippingMetabox() {
 		$this->mockPickupPointService();
 		$this->editOrderPage = new EditOrderPage( $this->mockPickupPointService );
-		$order = Mockery::mock( 'alias:WC_Order' );
-		$shippingLine = Mockery::mock( 'alias:WC_Order_Item_Shipping' );
+		$order = \Mockery::mock( 'alias:WC_Order' );
+		$shippingLine = \Mockery::mock( 'alias:WC_Order_Item_Shipping' );
 		$shippingLine->shouldReceive( 'get_id' )
 			->andReturn( '123' )
 			->once();
@@ -66,8 +69,8 @@ class EditOrderPageTest extends BaseTestCase {
 		$this->mockPickupPointService();
 
 		$this->editOrderPage = new EditOrderPage( $this->mockPickupPointService );
-		$order               = Mockery::mock( 'alias:WC_Order' );
-		$shippingLine        = Mockery::mock( 'alias:WC_Order_Item_Shipping' );
+		$order               = \Mockery::mock( 'alias:WC_Order' );
+		$shippingLine        = \Mockery::mock( 'alias:WC_Order_Item_Shipping' );
 
 		$shippingLine->shouldReceive( 'get_id' )
 			->andReturn( '123' )
@@ -81,7 +84,7 @@ class EditOrderPageTest extends BaseTestCase {
 			->andReturn( array( $shippingLine ) )
 			->once();
 
-		WP_Mock::userFunction( 'wp_kses_post' )->once();
+		\WP_Mock::userFunction( 'wp_kses_post' )->once();
 
 		ob_start();
 		$this->editOrderPage->print_selected_pickup_point_info( $order, $shippingLine );

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -1,23 +1,25 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\Assets;
 
 class AssetsTest extends BaseTestCase {
 	public function testCanRegisterAssets() {
 		$this->expectNotToPerformAssertions();
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'plugin_dir_url',
 			array(
 				'times'  => 1,
 				'return' => 'test',
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_register_script',
 			array(
 				'times' => 2,
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_register_style',
 			array(
 				'times' => 2,
@@ -31,43 +33,43 @@ class AssetsTest extends BaseTestCase {
 	public function testCanEnqueueAssets() {
 		$this->expectNotToPerformAssertions();
 		// Create a mock for WC_AJAX and the get_endpoint static method.
-		$mock = Mockery::mock( 'alias:WC_AJAX' );
+		$mock = \Mockery::mock( 'alias:WC_AJAX' );
 		$mock->shouldReceive( 'get_endpoint' )->andReturn( 'test' );
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'plugin_dir_url',
 			array(
 				'times'  => 1,
 				'return' => 'test',
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'is_checkout',
 			array(
 				'times'  => 1,
 				'return' => true,
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_create_nonce',
 			array(
 				'times'  => 1,
 				'return' => 'test',
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_localize_script',
 			array(
 				'times' => 1,
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_enqueue_script',
 			array(
 				'times' => 1,
 			)
 		);
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_enqueue_style',
 			array(
 				'times' => 1,
@@ -81,7 +83,7 @@ class AssetsTest extends BaseTestCase {
 	public function testDoesNotEnqueueOnNonCheckoutPages() {
 		$this->expectNotToPerformAssertions();
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'plugin_dir_url',
 			array(
 				'times'  => 1,
@@ -89,7 +91,7 @@ class AssetsTest extends BaseTestCase {
 			)
 		);
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'is_checkout',
 			array(
 				'times'  => 1,
@@ -97,7 +99,7 @@ class AssetsTest extends BaseTestCase {
 			)
 		);
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_create_nonce',
 			array(
 				'times'  => 0,

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\AJAX;
 use Krokedil\Shipping\Assets;
 use Krokedil\Shipping\Container\Container;
@@ -50,25 +52,25 @@ abstract class BaseTestCase extends TestCase {
 	);
 
 	public function mockShippingRate( $rate_id = 'rate_id' ) {
-		$shippingRate = Mockery::mock( 'alias:WC_Shipping_Rate' );
+		$shippingRate = \Mockery::mock( 'alias:WC_Shipping_Rate' );
 		$shippingRate->shouldReceive( 'get_id' )->andReturn( $rate_id );
 
 		return $shippingRate;
 	}
 
 	public function mockWooCommerce() {
-		$this->mockWoocommerce = Mockery::mock( 'WooCommerce' );
-		$this->mockShipping    = Mockery::mock( 'WC_Shipping' );
-		$this->mockSession     = Mockery::mock( 'WC_Session' );
-		$this->mockCart        = Mockery::mock( 'WC_Cart' );
-		$this->mockCountries   = Mockery::mock( 'WC_Countries' );
+		$this->mockWoocommerce = \Mockery::mock( 'WooCommerce' );
+		$this->mockShipping    = \Mockery::mock( 'WC_Shipping' );
+		$this->mockSession     = \Mockery::mock( 'WC_Session' );
+		$this->mockCart        = \Mockery::mock( 'WC_Cart' );
+		$this->mockCountries   = \Mockery::mock( 'WC_Countries' );
 
 		$this->mockWoocommerce->shouldReceive( 'shipping' )->andReturn( $this->mockShipping );
 		$this->mockWoocommerce->session   = $this->mockSession;
 		$this->mockWoocommerce->cart      = $this->mockCart;
 		$this->mockWoocommerce->countries = $this->mockCountries;
 
-		WP_Mock::userFunction( 'WC' )->andReturn( $this->mockWoocommerce );
+		\WP_Mock::userFunction( 'WC' )->andReturn( $this->mockWoocommerce );
 	}
 
 	public function mockPickupPointService() {
@@ -81,30 +83,30 @@ abstract class BaseTestCase extends TestCase {
 		$this->mockContainer->shouldReceive( 'get' )->with( 'ajax' )->andReturn( $this->mockAjax );
 		$this->mockContainer->shouldReceive( 'get' )->with( 'session-handler' )->andReturn( $this->mockSessionHandler );
 
-		$this->mockPickupPointService = Mockery::mock( PickupPointServiceInterface::class );
+		$this->mockPickupPointService = \Mockery::mock( PickupPointServiceInterface::class );
 
 		$this->mockPickupPointService->shouldReceive( 'get_container' )->andReturn( $this->mockContainer );
 	}
 
 	public function mockContainer() {
-		$this->mockContainer = Mockery::mock( Container::class );
+		$this->mockContainer = \Mockery::mock( Container::class );
 	}
 
 	public function mockAssetsRegistry() {
-		$this->mockAssets = Mockery::mock( Assets::class );
+		$this->mockAssets = \Mockery::mock( Assets::class );
 
 		$this->mockAssets->shouldReceive( 'register_assets' )->andReturn( null );
 		$this->mockAssets->shouldReceive( 'enqueue_assets' )->andReturn( null );
 	}
 
 	public function mockAjaxRegistry() {
-		$this->mockAjax = Mockery::mock( AJAX::class );
+		$this->mockAjax = \Mockery::mock( AJAX::class );
 
 		$this->mockAjax->shouldReceive( 'add_ajax_events' )->andReturn( null );
 		$this->mockAjax->shouldReceive( 'add_ajax_event' )->andReturn( null );
 	}
 
 	public function mockSessionHandler() {
-		$this->mockSessionHandler = Mockery::mock( SessionHandler::class );
+		$this->mockSessionHandler = \Mockery::mock( SessionHandler::class );
 	}
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\Calculations;
 
 class CalculationsTest extends BaseTestCase {
@@ -48,7 +50,7 @@ class CalculationsTest extends BaseTestCase {
 			),
 		);
 
-		$this->mockTax = Mockery::mock( 'alias:WC_Tax' );
+		$this->mockTax = \Mockery::mock( 'alias:WC_Tax' );
 		$this->mockTax->shouldReceive( 'get_shipping_tax_rates' )
 			->andReturn( array(
 				$this->rates['25'],

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1,6 +1,10 @@
 <?php
+namespace Krokedil\Shipping\Tests\Container;
+
 use Krokedil\Shipping\Container\Container;
 use Krokedil\Shipping\Container\Exceptions\NotFoundException;
+use Krokedil\Shipping\Tests\BaseTestCase;
+use stdClass;
 
 class ContainerTest extends BaseTestCase {
 	private $container;

--- a/tests/Frontend/PickupPointsSelectTest.php
+++ b/tests/Frontend/PickupPointsSelectTest.php
@@ -1,8 +1,12 @@
 <?php
+namespace Krokedil\Shipping\Tests\Frontend;
+
+use Exception;
 use Krokedil\Shipping\Frontend\PickupPointSelect;
 use Krokedil\Shipping\PickupPoint\PickupPoint;
+use Krokedil\Shipping\Tests\BaseTestCase;
 
-class PickupPointSelectTest extends BaseTestCase {
+class PickupPointsSelectTest extends BaseTestCase {
 	private $pickupPointSelect;
 
 	public function setUp(): void {
@@ -23,7 +27,7 @@ class PickupPointSelectTest extends BaseTestCase {
 
 		$rate = $this->mockShippingRate();
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'selected',
 			array(
 				'times' => 1,
@@ -79,7 +83,7 @@ class PickupPointSelectTest extends BaseTestCase {
 		$this->mockPickupPointService->shouldReceive( 'get_pickup_point_from_rate_by_id' )->with( $rate, '123' )->once()->andReturn( $pickupPointObj );
 		$this->mockPickupPointService->shouldReceive( 'save_selected_pickup_point_to_rate' )->with( $rate, $pickupPointObj )->once()->andReturn( null );
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'is_wp_error',
 			array(
 				'times'  => 1,
@@ -87,7 +91,7 @@ class PickupPointSelectTest extends BaseTestCase {
 			)
 		);
 
-		WP_Mock::userFunction(
+		\WP_Mock::userFunction(
 			'wp_send_json_success',
 			array(
 				'times' => 1,
@@ -112,7 +116,7 @@ class PickupPointSelectTest extends BaseTestCase {
 		$this->expectException( Exception::class );
 		$_POST = array();
 
-		WP_Mock::userFunction( 'wp_send_json_error' )->once()->andThrows( new Exception() );
+		\WP_Mock::userFunction( 'wp_send_json_error' )->once()->andThrows( new Exception() );
 
 		$this->pickupPointSelect->set_selected_pickup_point_ajax();
 	}

--- a/tests/PickupPoint/AddressTest.php
+++ b/tests/PickupPoint/AddressTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\PickupPoint;
+
 use Krokedil\Shipping\PickupPoint\Address;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/PickupPoint/CoordinatesTest.php
+++ b/tests/PickupPoint/CoordinatesTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\PickupPoint;
+
 use Krokedil\Shipping\PickupPoint\Coordinates;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/PickupPoint/EstimatedTimeOfArrivalTest.php
+++ b/tests/PickupPoint/EstimatedTimeOfArrivalTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\PickupPoint;
+
 use Krokedil\Shipping\PickupPoint\EstimatedTimeOfArrival;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/PickupPoint/OpenHoursTest.php
+++ b/tests/PickupPoint/OpenHoursTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\PickupPoint;
+
 use Krokedil\Shipping\PickupPoint\OpenHours;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/PickupPoint/PickupPointTest.php
+++ b/tests/PickupPoint/PickupPointTest.php
@@ -1,9 +1,12 @@
 <?php
+namespace Krokedil\Shipping\Tests\PickupPoint;
+
 use Krokedil\Shipping\PickupPoint\PickupPoint;
 use Krokedil\Shipping\PickupPoint\Address;
 use Krokedil\Shipping\PickupPoint\Coordinates;
 use Krokedil\Shipping\PickupPoint\OpenHours;
 use Krokedil\Shipping\PickupPoint\EstimatedTimeOfArrival;
+use Krokedil\Shipping\Tests\BaseTestCase;
 
 class PickupPointTest extends BaseTestCase {
 

--- a/tests/PickupPointsTest.php
+++ b/tests/PickupPointsTest.php
@@ -33,6 +33,24 @@ class PickupPointsTest extends BaseTestCase {
 		$this->pickupPoints = new PickupPoints( '', true );
 	}
 
+	public function mockSessionGetAndSetSelectedPickupPoint( $pickupPoint ) {
+		$this->mockSession->shouldReceive( 'get')->with( 'krokedil_selected_pickup_point_id' )->andReturn( null )->once();
+		$this->mockSession->shouldReceive( 'set')->with( 'krokedil_selected_pickup_point_id', $pickupPoint['id'] )->once();
+		$this->mockSession->shouldReceive( 'set')->with( 'krokedil_selected_pickup_point', json_encode($pickupPoint) )->once();
+		$this->mockWooCommerce();
+	}
+
+	public function mockSessionGetSelectedPickupPoint() {
+		$this->mockSession->shouldReceive( 'get')->with( 'krokedil_selected_pickup_point_id' )->andReturn( null )->once();
+		$this->mockWooCommerce();
+	}
+
+	public function mockSessionSetSelectedPickupPoint( $pickupPoint ) {
+		$this->mockSession->shouldReceive( 'set')->with( 'krokedil_selected_pickup_point_id', $pickupPoint['id'] )->once();
+		$this->mockSession->shouldReceive( 'set')->with( 'krokedil_selected_pickup_point', json_encode($pickupPoint) )->once();
+		$this->mockWooCommerce();
+	}
+
 	public function testGetContainer() {
 		$result = $this->pickupPoints->get_container();
 
@@ -40,6 +58,8 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testSavePickupPointsToRate() {
+		$this->mockSessionGetAndSetSelectedPickupPoint( self::$pickupPoint );
+
 		$rate = $this->mockShippingRate();
 		$rate->shouldReceive( 'get_meta_data' )
 			->andReturn( array(  ) )
@@ -65,6 +85,8 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testSavePickupPointsToRateForceSave() {
+		$this->mockSessionGetAndSetSelectedPickupPoint( self::$pickupPoint );
+
 		$rate = $this->mockShippingRate();
 		$rate->shouldReceive( 'get_meta_data' )
 			->andReturn( array(  ) )
@@ -103,6 +125,8 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testAddPickupPointToRate() {
+		$this->mockSessionGetAndSetSelectedPickupPoint( self::$pickupPoint );
+
 		$pickupPoint = new PickupPoint( self::$pickupPoint );
 
 		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
@@ -151,6 +175,7 @@ class PickupPointsTest extends BaseTestCase {
 		$pickupPoint2       = self::$pickupPoint;
 		$pickupPoint2['id'] = '321';
 
+		$this->mockSessionGetAndSetSelectedPickupPoint($pickupPoint2);
 		$toRemove = new PickupPoint( self::$pickupPoint );
 
 		$rate->shouldReceive( 'get_meta_data' )
@@ -187,6 +212,7 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testSaveSelectedPickupPointToRate() {
+		$this->mockSessionSetSelectedPickupPoint(self::$pickupPoint);
 		$rate = $this->mockShippingRate();
 
 		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
@@ -207,6 +233,7 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testGetSelectedPickupPointFromRate() {
+		$this->mockSessionGetSelectedPickupPoint();
 		$rate = $this->mockShippingRate();
 
 		$rate->shouldReceive( 'get_meta_data' )
@@ -219,6 +246,7 @@ class PickupPointsTest extends BaseTestCase {
 	}
 
 	public function testGetSelectedPickupPointFromRateFalseIfNoSelectedExists() {
+		$this->mockSessionGetSelectedPickupPoint();
 		$rate = $this->mockShippingRate();
 
 		$rate->shouldReceive( 'get_meta_data' )

--- a/tests/PickupPointsTest.php
+++ b/tests/PickupPointsTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\PickupPoint\PickupPoint;
 use Krokedil\Shipping\PickupPoints;
 use Krokedil\Shipping\Container\Container;
@@ -18,14 +20,14 @@ class PickupPointsTest extends BaseTestCase {
 		$this->mockShipping->allows( 'calculate_shipping_for_package' )->andReturn( null );
 		$this->mockSession->allows( '__unset' )->andReturn( null );
 
-		WP_Mock::userFunction( 'plugin_dir_url' )->andReturn( 'http://example.com/wp-content/plugins/my-plugin/' );
+		\WP_Mock::userFunction( 'plugin_dir_url' )->andReturn( 'http://example.com/wp-content/plugins/my-plugin/' );
 
-		WP_Mock::userFunction( 'wp_create_nonce', array(
+		\WP_Mock::userFunction( 'wp_create_nonce', array(
 			'args'   => array( 'krokedil_shipping_set_selected_pickup_point' ),
 			'return' => 'some_nonce',
 		) );
 
-		$wcAjaxMock = Mockery::mock( 'alias:WC_AJAX' );
+		$wcAjaxMock = \Mockery::mock( 'alias:WC_AJAX' );
 		$wcAjaxMock->shouldReceive( 'get_endpoint' )
 			->with( 'krokedil_shipping_set_selected_pickup_point' )
 			->andReturn( 'some_url' );
@@ -74,8 +76,8 @@ class PickupPointsTest extends BaseTestCase {
 			->with( 'krokedil_pickup_points', json_encode( array( self::$pickupPoint ) ) )
 			->once();
 
-		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
-		WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_action' )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
 
 		$pickupPoint = new PickupPoint( self::$pickupPoint );
 
@@ -91,8 +93,8 @@ class PickupPointsTest extends BaseTestCase {
 		$rate->shouldReceive( 'get_meta_data' )
 			->andReturn( array(  ) )
 			->once();
-		WP_Mock::userFunction( 'doing_action' )->andReturn( false );
-		WP_Mock::userFunction( 'doing_filter', )->andReturn( false );
+		\WP_Mock::userFunction( 'doing_action' )->andReturn( false );
+		\WP_Mock::userFunction( 'doing_filter', )->andReturn( false );
 
 		$pickupPoint = new PickupPoint( self::$pickupPoint );
 
@@ -129,8 +131,8 @@ class PickupPointsTest extends BaseTestCase {
 
 		$pickupPoint = new PickupPoint( self::$pickupPoint );
 
-		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
-		WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_action' )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
 
 		$rate = $this->mockShippingRate();
 		$rate->shouldReceive( 'add_meta_data' )
@@ -169,8 +171,8 @@ class PickupPointsTest extends BaseTestCase {
 	public function testRemovePickupPointFromRate() {
 		$rate = $this->mockShippingRate();
 
-		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
-		WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_action' )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
 
 		$pickupPoint2       = self::$pickupPoint;
 		$pickupPoint2['id'] = '321';
@@ -215,8 +217,8 @@ class PickupPointsTest extends BaseTestCase {
 		$this->mockSessionSetSelectedPickupPoint(self::$pickupPoint);
 		$rate = $this->mockShippingRate();
 
-		WP_Mock::userFunction( 'doing_action' )->andReturn( true );
-		WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_action' )->andReturn( true );
+		\WP_Mock::userFunction( 'doing_filter', )->andReturn( true );
 
 		$rate->shouldReceive( 'add_meta_data' )
 			->with( 'krokedil_selected_pickup_point', json_encode( self::$pickupPoint ) )

--- a/tests/SessionHandlerTest.php
+++ b/tests/SessionHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests;
+
 use Krokedil\Shipping\SessionHandler;
 
 class SessionHandlerTest extends BaseTestCase {
@@ -46,7 +48,7 @@ class SessionHandlerTest extends BaseTestCase {
 		$this->mockSession->shouldReceive( '__unset' )->times( 3 );
 		$this->mockShipping->shouldReceive( 'calculate_shipping_for_package' )->times( 3 );
 
-		$packages = [ 
+		$packages = [
 			[ 'rates' => [] ],
 			[ 'rates' => [] ],
 			[ 'rates' => [] ],
@@ -70,7 +72,7 @@ class SessionHandlerTest extends BaseTestCase {
 	}
 
 	public function testPackageRatesHandlerUpdatesRatesWithData() {
-		$rateData = [ 
+		$rateData = [
 			'rate_id1' => [ 'meta_key1' => 'meta_value1' ],
 			'rate_id2' => [ 'meta_key2' => 'meta_value2' ],
 		];
@@ -104,6 +106,6 @@ class SessionHandlerTest extends BaseTestCase {
 
 	public function tearDown(): void {
 		parent::tearDown();
-		Mockery::close();
+		\Mockery::close();
 	}
 }

--- a/tests/Traits/ArrayFormatTest.php
+++ b/tests/Traits/ArrayFormatTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\Traits;
+
 use Krokedil\Shipping\Traits\ArrayFormat;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/Traits/JsonFormatTest.php
+++ b/tests/Traits/JsonFormatTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Krokedil\Shipping\Tests\Traits;
+
 use Krokedil\Shipping\Traits\JsonFormat;
 use WP_Mock\Tools\TestCase;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,6 @@
 // Load Composer autoloader.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
-// Load our base test case class.
-require_once 'BaseTestCase.php';
-
 // Load WP_Mock
-WP_Mock::setUsePatchwork( true );
-WP_Mock::bootstrap();
+\WP_Mock::setUsePatchwork( true );
+\WP_Mock::bootstrap();


### PR DESCRIPTION
## [2.3.0] - 2025-07-16

### Added
* Added a improved error handling for shipping methods that have been changed during the checkout process. If the shipping package is used, instead of letting WooCommerce set the first shipping method, it will now throw an error that stops the checkout process and informs the customer that the shipping methods have changed. This has to be enabled with the filter `krokedil_shipping_should_verify_shipping` which is set to false by default to prevent unwanted behavior in existing setups.
* Added a filter `krokedil_shipping_changed_auto_correct` to allow developers to auto-correct the shipping method if it has been changed during the checkout process. This is useful if you want to automatically set the shipping method to the first available one instead of throwing an error. However this is not recommended as it can lead to unexpected issues if the chosen method is no longer available.
* Added a filter `krokedil_shipping_changed_throw_error` to allow merchants or plugins to disable the error handling for shipping methods that have been changed during the checkout process. This is useful if you want to handle the error in your own way, or if you want to disable the error handling completely, for example for specific payment or shipping methods.

### Fixed
* Fixed an issue where the shipping methods selected pickup point would be reset in some cases when the shipping methods were recalculated.