### PR TITLE
Default to empty array

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Add array as default value to chosen_shipping_methods in the shipping rate output method to avoid PHP errors. 
+
 ------------------
 ## [2.3.2] - 2025-10-14
 

--- a/src/Frontend/PickupPointSelect.php
+++ b/src/Frontend/PickupPointSelect.php
@@ -58,7 +58,7 @@ class PickupPointSelect {
 	 */
 	public function render( $shipping_rate ) {
 		// Only if this is the selected shipping rate.
-		if ( ! in_array( $shipping_rate->get_id(), WC()->session->get( 'chosen_shipping_methods', array() ), true ) ) {
+		if ( ! in_array( $shipping_rate->get_id(), WC()->session->get( 'chosen_shipping_methods' ) ?? array(), true ) ) {
 			return;
 		}
 

--- a/src/Frontend/ShippingRateOutput.php
+++ b/src/Frontend/ShippingRateOutput.php
@@ -28,12 +28,12 @@ class ShippingRateOutput {
 	/**
 	 * Returns true if the element should be output for the shipping rate.
 	 *
-	 * @param string $element
+	 * @param string            $element
 	 * @param \WC_Shipping_Rate $shipping_rate
 	 */
 	public function should_output( $element, $shipping_rate ) {
 		// Only if this is the selected shipping rate.
-		if ( ! in_array( $shipping_rate->get_id(), WC()->session->get( 'chosen_shipping_methods' ), true ) ) {
+		if ( ! in_array( $shipping_rate->get_id(), WC()->session->get( 'chosen_shipping_methods' ) ?? array(), true ) ) {
 			return false;
 		}
 
@@ -56,7 +56,7 @@ class ShippingRateOutput {
 		// Get the description for the shipping rate.
 		$description = $this->shipping_rate_service->get_shipping_rate_description( $shipping_rate );
 
-		if ( ! empty( $description ) && 0 === did_action('krokedil_shipping_before_rate_description') ) {
+		if ( ! empty( $description ) && 0 === did_action( 'krokedil_shipping_before_rate_description' ) ) {
 			do_action( 'krokedil_shipping_before_rate_description' );
 			echo '<div class="krokedil_shipping_description">' . wp_kses_post( $description ) . '</div>';
 			do_action( 'krokedil_shipping_after_rate_description' );


### PR DESCRIPTION
Default to empty array if session 'chosen_shipping_methods' does not exist or if set to null, do avoid potential fatal error "PHP Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array".