### PR TITLE
Version update (2.4.0)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+------------------
+
+## [2.4.0] - 2026-04-29
+
 ### Added
 * Added support for setting the shipping carrier to the rate using the ShippingRate class.
+* Added filter krokedil_shipping_pickup_point_name so other plugins can modify the pickup point name.
 
 ### Fixed
 * Fixed an issue where the selected pickup point was reset when shipping methods were updated save_pickup_points_to_rate now sets the krokedil_pickup_points rate metadata before checking for the previously selected pickup point.
 
-------------------
 ## [2.3.3] - 2026-01-23
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added support for setting the shipping carrier to the rate using the ShippingRate class.
 
+### Fixed
+* Fixed an issue where the selected pickup point was reset when shipping methods were updated save_pickup_points_to_rate now sets the krokedil_pickup_points rate metadata before checking for the previously selected pickup point.
+
 ------------------
 ## [2.3.3] - 2026-01-23
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Added support for setting the shipping carrier to the rate using the ShippingRate class.
 
 ------------------
 ## [2.3.2] - 2025-10-14

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "krokedil/shipping",
     "description": "Shipping method extensions from Krokedil",
     "type": "library",
-    "version": "2.3.3",
+    "version": "2.4.0",
     "require": {
         "php": "~7.4 || ~8.0",
         "psr/container": "2.0.x-dev"

--- a/src/Interfaces/ShippingRateServiceInterface.php
+++ b/src/Interfaces/ShippingRateServiceInterface.php
@@ -26,10 +26,18 @@ interface ShippingRateServiceInterface {
 	/**
 	 * Save the description for a shipping rate.
 	 *
-	 * @param \WC_Shipping_Rate $rate The shipping rate to save the description for.
+	 * @param \WC_Shipping_Rate $rate The shipping rate to save the description to.
 	 * @param string $description The description to save.
 	 */
 	public function save_shipping_rate_description( $rate, $description );
+
+	/**
+	 * Save the carrier for a shipping rate.
+	 *
+	 * @param \WC_Shipping_Rate $rate The shipping rate to save the carrier to.
+	 * @param string $carrier The carrier to save.
+	 */
+	public function save_shipping_rate_carrier( $rate, $carrier );
 
 	/**
 	 * Get the description for a shipping rate.
@@ -39,4 +47,13 @@ interface ShippingRateServiceInterface {
 	 * @return string
 	 */
 	public function get_shipping_rate_description( $rate );
+
+	/**
+	 * Get the carrier for a shipping rate.
+	 *
+	 * @param \WC_Shipping_Rate $rate The shipping rate to get the carrier for.
+	 *
+	 * @return string
+	 */
+	public function get_shipping_rate_carrier( $rate );
 }

--- a/src/PickupPoints.php
+++ b/src/PickupPoints.php
@@ -90,34 +90,33 @@ class PickupPoints implements PickupPointServiceInterface {
 	private $packages = null;
 
 	/**
-     * Save the pickup points for a specific rate.
-     *
-     * @param \WC_Shipping_Rate  $rate The WooCommerce shipping rate to save the pickup points to.
-     * @param array<PickupPoint> $pickup_points The pickup points to save.
-     *
-     * @return void
-     */
-    public function save_pickup_points_to_rate( $rate, $pickup_points )
-    {
-        $pickup_points_json = $this->to_json( $pickup_points );
-        $data               = array( 'krokedil_pickup_points' => $pickup_points_json );
-        $rate->add_meta_data( 'krokedil_pickup_points', $pickup_points_json );
+	 * Save the pickup points for a specific rate.
+	 *
+	 * @param \WC_Shipping_Rate  $rate The WooCommerce shipping rate to save the pickup points to.
+	 * @param array<PickupPoint> $pickup_points The pickup points to save.
+	 *
+	 * @return void
+	 */
+	public function save_pickup_points_to_rate( $rate, $pickup_points ) {
+		$pickup_points_json = $this->to_json( $pickup_points );
+		$data               = array( 'krokedil_pickup_points' => $pickup_points_json );
+		$rate->add_meta_data( 'krokedil_pickup_points', $pickup_points_json );
 
-        $selected_pickup_point = $this->get_selected_pickup_point_from_rate( $rate );
+		$selected_pickup_point = $this->get_selected_pickup_point_from_rate( $rate );
 
-        // Does the rate have any selected pickup points? If not set the first one as the selected pickup point.
-        if ( ! $selected_pickup_point && ! empty( $pickup_points ) ) {
-            $pickup_point_json = $this->to_json( $pickup_points[0] );
-            $data['krokedil_selected_pickup_point']    = $pickup_point_json;
-            $data['krokedil_selected_pickup_point_id'] = $pickup_points[0]->get_id();
-        } elseif( $selected_pickup_point ) {
-            $data['krokedil_selected_pickup_point_id'] = $selected_pickup_point->get_id();
-            $data['krokedil_selected_pickup_point']    = $this->to_json($selected_pickup_point);
+		// Does the rate have any selected pickup points? If not set the first one as the selected pickup point.
+		if ( ! $selected_pickup_point && ! empty( $pickup_points ) ) {
+			$pickup_point_json                         = $this->to_json( $pickup_points[0] );
+			$data['krokedil_selected_pickup_point']    = $pickup_point_json;
+			$data['krokedil_selected_pickup_point_id'] = $pickup_points[0]->get_id();
+		} elseif ( $selected_pickup_point ) {
+			$data['krokedil_selected_pickup_point_id'] = $selected_pickup_point->get_id();
+			$data['krokedil_selected_pickup_point']    = $this->to_json( $selected_pickup_point );
 
-        }
+		}
 
-        $this->save_shipping_rate_data($rate, $data);
-    }
+		$this->save_shipping_rate_data( $rate, $data );
+	}
 
 	/**
 	 * Get the pickup points for a specific rate.

--- a/src/PickupPoints.php
+++ b/src/PickupPoints.php
@@ -97,17 +97,17 @@ class PickupPoints implements PickupPointServiceInterface {
      *
      * @return void
      */
-    public function save_pickup_points_to_rate($rate, $pickup_points)
+    public function save_pickup_points_to_rate( $rate, $pickup_points )
     {
-        $pickup_points_json = $this->to_json($pickup_points);
-        $data = array('krokedil_pickup_points' => $pickup_points_json);
+        $pickup_points_json = $this->to_json( $pickup_points );
+        $data               = array( 'krokedil_pickup_points' => $pickup_points_json );
         $rate->add_meta_data( 'krokedil_pickup_points', $pickup_points_json );
 
-        $selected_pickup_point = $this->get_selected_pickup_point_from_rate($rate);
+        $selected_pickup_point = $this->get_selected_pickup_point_from_rate( $rate );
 
         // Does the rate have any selected pickup points? If not set the first one as the selected pickup point.
-        if (!$selected_pickup_point && !empty($pickup_points)) {
-            $pickup_point_json = $this->to_json($pickup_points[0]);
+        if ( ! $selected_pickup_point && ! empty( $pickup_points ) ) {
+            $pickup_point_json = $this->to_json( $pickup_points[0] );
             $data['krokedil_selected_pickup_point']    = $pickup_point_json;
             $data['krokedil_selected_pickup_point_id'] = $pickup_points[0]->get_id();
         } elseif( $selected_pickup_point ) {

--- a/src/PickupPoints.php
+++ b/src/PickupPoints.php
@@ -90,27 +90,34 @@ class PickupPoints implements PickupPointServiceInterface {
 	private $packages = null;
 
 	/**
-	 * Save the pickup points for a specific rate.
-	 *
-	 * @param \WC_Shipping_Rate  $rate The WooCommerce shipping rate to save the pickup points to.
-	 * @param array<PickupPoint> $pickup_points The pickup points to save.
-	 *
-	 * @return void
-	 */
-	public function save_pickup_points_to_rate( $rate, $pickup_points ) {
-		$pickup_points_json = $this->to_json( $pickup_points );
+     * Save the pickup points for a specific rate.
+     *
+     * @param \WC_Shipping_Rate  $rate The WooCommerce shipping rate to save the pickup points to.
+     * @param array<PickupPoint> $pickup_points The pickup points to save.
+     *
+     * @return void
+     */
+    public function save_pickup_points_to_rate($rate, $pickup_points)
+    {
+        $pickup_points_json = $this->to_json($pickup_points);
+        $data = array('krokedil_pickup_points' => $pickup_points_json);
+        $rate->add_meta_data( 'krokedil_pickup_points', $pickup_points_json );
 
-		$data = array(
-			'krokedil_pickup_points' => $pickup_points_json,
-		);
+        $selected_pickup_point = $this->get_selected_pickup_point_from_rate($rate);
 
-		// Does the rate have any selected pickup points? If not set the first one as the selected pickup point.
-		if ( ! $this->get_selected_pickup_point_from_rate( $rate ) && ! empty( $pickup_points ) ) {
-			$this->save_selected_pickup_point_to_rate( $rate, $pickup_points[0] );
-		}
+        // Does the rate have any selected pickup points? If not set the first one as the selected pickup point.
+        if (!$selected_pickup_point && !empty($pickup_points)) {
+            $pickup_point_json = $this->to_json($pickup_points[0]);
+            $data['krokedil_selected_pickup_point']    = $pickup_point_json;
+            $data['krokedil_selected_pickup_point_id'] = $pickup_points[0]->get_id();
+        } elseif( $selected_pickup_point ) {
+            $data['krokedil_selected_pickup_point_id'] = $selected_pickup_point->get_id();
+            $data['krokedil_selected_pickup_point']    = $this->to_json($selected_pickup_point);
 
-		$this->save_shipping_rate_data( $rate, $data );
-	}
+        }
+
+        $this->save_shipping_rate_data($rate, $data);
+    }
 
 	/**
 	 * Get the pickup points for a specific rate.

--- a/src/ShippingRate.php
+++ b/src/ShippingRate.php
@@ -19,6 +19,7 @@ class ShippingRate implements ShippingRateServiceInterface {
 	 */
 	private $args = array(
 		'show_description' => true,
+		'show_carrier'     => false,
 	);
 
 	/**
@@ -68,6 +69,7 @@ class ShippingRate implements ShippingRateServiceInterface {
 		}
 
 		$hidden_order_itemmeta[] = 'krokedil_description';
+		$hidden_order_itemmeta[] = 'krokedil_carrier';
 
 		return $hidden_order_itemmeta;
 	}
@@ -108,5 +110,29 @@ class ShippingRate implements ShippingRateServiceInterface {
 	 */
 	public function should_output( $element ) {
 		return $this->args[ "show_{$element}" ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function save_shipping_rate_carrier( $rate, $carrier ) {
+		// If the carrier is empty, return.
+		if ( empty( $carrier ) ) {
+			return;
+		}
+
+		$this->save_shipping_rate_data( $rate, array( 'krokedil_carrier' => $carrier ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_shipping_rate_carrier( $rate ) {
+		$meta_data = $rate->get_meta_data();
+		if ( ! array_key_exists( 'krokedil_carrier', $meta_data ) ) {
+			return '';
+		}
+
+		return $meta_data['krokedil_carrier'];
 	}
 }

--- a/src/templates/html-pickup-point-select.php
+++ b/src/templates/html-pickup-point-select.php
@@ -17,7 +17,7 @@ if ( empty( $pickup_points ) ) {
 		<?php foreach ( $pickup_points as $pickup_point ) : ?>
 			<option class="krokedil_shipping_pickup_point__option"
 				value="<?php echo esc_attr( $pickup_point->get_id() ); ?>" <?php selected( $pickup_point->get_id(), $selected_pickup_point ? $selected_pickup_point->get_id() : $pickup_points[0]->get_id() ); ?>>
-				<?php echo esc_html( $pickup_point->get_name() ); ?>
+				<?php echo esc_html( apply_filters( 'krokedil_shipping_pickup_point_name', $pickup_point->get_name(), $pickup_point, $rate_id, $selected_pickup_point ) ); ?>
 			</option>
 		<?php endforeach; ?>
 	</select>


### PR DESCRIPTION
### Added
* Added support for setting the shipping carrier to the rate using the ShippingRate class.
* Added filter krokedil_shipping_pickup_point_name so other plugins can modify the pickup point name.

### Fixed
* Fixed an issue where the selected pickup point was reset when shipping methods were updated save_pickup_points_to_rate now sets the krokedil_pickup_points rate metadata before checking for the previously selected pickup point.